### PR TITLE
updating ec2 tag keys to match other EC2 libraries

### DIFF
--- a/lib/circonus-cmi/aws.js
+++ b/lib/circonus-cmi/aws.js
@@ -52,9 +52,9 @@ util.inherits(list, events.EventEmitter);
 list.prototype.mktags = function(n) {
     var tags = [];
     if(n.Region) tags.push("ec2-region:" + n.Region);
-    if(n.AvailabilityZone) tags.push("ec2-zone:" + n.AvailabilityZone);
-    if(n.InstanceId) tags.push("ec2-id:" + n.InstanceId);
-    if(n.InstanceType) tags.push("ec2-type:" + n.InstanceType);
+    if(n.AvailabilityZone) tags.push("ec2-availability_zone:" + n.AvailabilityZone);
+    if(n.InstanceId) tags.push("ec2-instance_id:" + n.InstanceId);
+    if(n.InstanceType) tags.push("ec2-instance_type:" + n.InstanceType);
     return tags;
 };
 var non_ec2_tags = function(a) {


### PR DESCRIPTION
This is just a suggested change to make the tag keys match a little more with the API and other libraries. Within the EC2 API itself, there are multiple "ids" and "types", so IMO this is a little clearer. 
