### PR TITLE
Update to how tags are named for Circonus tagging.

### DIFF
--- a/lib/circonus-cmi/aws.js
+++ b/lib/circonus-cmi/aws.js
@@ -51,15 +51,15 @@ util.inherits(list, events.EventEmitter);
 
 list.prototype.mktags = function(n) {
     var tags = [];
-    if(n.Region) tags.push("ec2-region:" + n.Region);
-    if(n.AvailabilityZone) tags.push("ec2-zone:" + n.AvailabilityZone);
-    if(n.InstanceId) tags.push("ec2-id:" + n.InstanceId);
-    if(n.InstanceType) tags.push("ec2-type:" + n.InstanceType);
+    if(n.Region) tags.push("aws-ec2-region:" + n.Region);
+    if(n.AvailabilityZone) tags.push("aws-ec2-availability_zone:" + n.AvailabilityZone);
+    if(n.InstanceId) tags.push("aws-ec2-instance_id:" + n.InstanceId);
+    if(n.InstanceType) tags.push("aws-ec2-instance_type:" + n.InstanceType);
     return tags;
 };
 var non_ec2_tags = function(a) {
     if(!/:/.test(a)) return false;
-    return !/^ec2-/.test(a);
+    return !/^(?:ec2|aws)-/.test(a);
 };
 list.prototype.doregion = function(r) {
     var self = this;
@@ -86,7 +86,7 @@ list.prototype.doregion = function(r) {
                         if(inst.Tags) {
                           inst.Tags.map(function(tobj) {
                             if(tobj.Key !== null && tobj.Value !== null) {
-                              o.tags.push('ec2-tag-' + tobj.Key.toLowerCase() + ':' + tobj.Value.toLowerCase());
+                              o.tags.push('aws-tag-' + tobj.Key.toLowerCase() + ':' + tobj.Value.toLowerCase());
                             }
                           });
                         }

--- a/lib/circonus-cmi/circonus.js
+++ b/lib/circonus-cmi/circonus.js
@@ -52,7 +52,7 @@ util.inherits(list, events.EventEmitter);
 
 function non_ec2_tags(a) {
     if(!/:/.test(a)) return false;
-    return !/^ec2-/.test(a);
+    return !/^(?:ec2|aws)-/.test(a);
 }
 
 list.prototype.find_nodes = function() {


### PR DESCRIPTION
Made a couple of changes to how tags are created - use better names for
the tags and prepend the tags with "aws" to make it clear that they are
AWS tags. Update the test to find user-created vs cmi-tool created tags
to look for tags starting with either "ec2-" or "aws-".
